### PR TITLE
Fix lunch place migration issue

### DIFF
--- a/app/models/lunch_place.rb
+++ b/app/models/lunch_place.rb
@@ -3,6 +3,6 @@
 class LunchPlace < ApplicationRecord
   belongs_to :user
 
-  validates :user_id, presence: true
-  validates :google_places_id, uniqueness: true
+  validates :user_id, presence: true, index: true
+  validates :google_places_id, presence: true
 end

--- a/app/models/lunch_place.rb
+++ b/app/models/lunch_place.rb
@@ -3,6 +3,6 @@
 class LunchPlace < ApplicationRecord
   belongs_to :user
 
-  validates :user_id, presence: true, index: true
+  validates :user_id, presence: true
   validates :google_places_id, presence: true
 end

--- a/db/migrate/20220217011400_add_index_to_google_places_id_column.rb
+++ b/db/migrate/20220217011400_add_index_to_google_places_id_column.rb
@@ -1,5 +1,0 @@
-class AddIndexToGooglePlacesIdColumn < ActiveRecord::Migration[6.0]
-  def change
-    add_index :lunch_places, :google_places_id, unique: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_17_011400) do
+ActiveRecord::Schema.define(version: 2022_02_16_231543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,6 @@ ActiveRecord::Schema.define(version: 2022_02_17_011400) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["google_places_id"], name: "index_lunch_places_on_google_places_id", unique: true
     t.index ["user_id"], name: "index_lunch_places_on_user_id"
   end
 


### PR DESCRIPTION
Refactor `lunch_places` table migration

1. remove index from `google_places_id` column
1. add index to `user_id` column
1. replace `uniqueness` constraint with `presence` for `google_places_id` column

For the 1st, I don't remember why I added it and removing it for now, as I don't see a use case for that at the moment 🤔 

For the 3rd one, I encountered an error when trying to add the same lunch place for a different user 🤦‍♀️ 
Since the idea is that several users can add same lunch place to their collection, making google place ID unique is wrong.

